### PR TITLE
Edit page error for geowidget

### DIFF
--- a/wagtailgeowidget/widgets.py
+++ b/wagtailgeowidget/widgets.py
@@ -82,7 +82,7 @@ if WAGTAIL_VERSION >= (6, 0):
                         "lng": result["x"],
                     }
 
-            if self.value_data and isinstance(self.value_data, Point):
+            if self.value_data and Point and isinstance(self.value_data, Point):
                 data["defaultLocation"] = {
                     "lat": self.value_data.y,
                     "lng": self.value_data.x,
@@ -264,7 +264,7 @@ if WAGTAIL_VERSION >= (6, 0):
                         "lng": result["x"],
                     }
 
-            elif self.value_data and isinstance(self.value_data, Point):
+            if self.value_data and Point and isinstance(self.value_data, Point):
                 data["defaultLocation"] = {
                     "lat": self.value_data.y,
                     "lng": self.value_data.x,


### PR DESCRIPTION
We noticed some errors reported in logs on a site. https://torchbox.sentry.io/issues/5287220301/?alert_rule_id=7114773&alert_type=issue&notification_uuid=43a26aeb-089e-4e77-8eba-12e08eb784d8&project=5303357

It turns out there's a small regression in the forks main branch following the latest merges here: https://github.com/torchbox-forks/wagtail-geo-widget/commit/1ab86c6ab380bae4b10b0cc249f8c5cf46d6700e 

This adds checks back in to test for Point having a value before it's used for comparison.