### PR TITLE
Wagtail 6.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
           - 6.2
     services:
       postgres:
-        image: postgis/postgis:12-2.5
+        image: postgis/postgis:13-3.4
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_USER: postgres

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
           - 5.2
           - 6.0
           - 6.1
+          - 6.2
     services:
       postgres:
         image: postgis/postgis:12-2.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Added
 - Drop support for Wagtail < 5.2 (@katdom13)
 - Add support for Wagtail 6.0/6.1 (@katdom13)
+- Add support for Wagtail 6.2 (@engineervix)
 
 ### Changed
 - Implement stimulus approach to GoogleMapsField, GeocoderField, and LeafletField (@katdom13)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim
-MAINTAINER Frojd
+LABEL maintainer="Frojd"
 LABEL version="v0.1.0"
 
 ENV PYTHONUNBUFFERED=1 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 # Local/Dev
-version: '3'
+version: "3"
 services:
   web:
     image: frojd/geo-widget-web
@@ -20,7 +20,7 @@ services:
       - DATABASE_PORT=5432
     env_file: web.env
   db:
-    image: postgis/postgis:12-2.5
+    image: postgis/postgis:13-3.4
     restart: always
     environment:
       - POSTGRES_USER=postgres

--- a/tests/examplesite/settings/base.py
+++ b/tests/examplesite/settings/base.py
@@ -35,6 +35,7 @@ WAGTAIL_APPS = [
     "wagtail.documents",
     "wagtail.images",
     "wagtail.search",
+    "wagtail.contrib.search_promotions",
     "wagtail.admin",
     "wagtail",
 ]

--- a/tests/geopage/models.py
+++ b/tests/geopage/models.py
@@ -272,7 +272,7 @@ class ClassicGeoPageWithLeaflet(Page):
     ]
 
     def get_context(self, request):
-        data = super(ClassicGeoPage, self).get_context(request)
+        data = super().get_context(request)
         return data
 
     @cached_property

--- a/tests/geopage/templates/geopage/classic_geo_page_with_leaflet.html
+++ b/tests/geopage/templates/geopage/classic_geo_page_with_leaflet.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% load wagtailcore_tags %}
+
+{% block content %}
+    <h1>{{ page.title }}</h1>
+
+    <ul>
+        <li>
+            Point: {{ page.point }}
+        </li>
+        <li>
+            Lat: {{ page.lat }}
+        </li>
+        <li>
+            Lng: {{ page.lng }}
+        </li>
+    </ul>
+{% endblock %}

--- a/tests/geopage/templates/geopage/classic_geo_page_with_leaflet_and_zoom.html
+++ b/tests/geopage/templates/geopage/classic_geo_page_with_leaflet_and_zoom.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% load wagtailcore_tags %}
+
+{% block content %}
+    <h1>{{ page.title }}</h1>
+
+    <ul>
+        <li>
+            Point: {{ page.point }}
+        </li>
+        <li>
+            Lat: {{ page.lat }}
+        </li>
+        <li>
+            Lng: {{ page.lng }}
+        </li>
+    </ul>
+{% endblock %}

--- a/tests/geopage/templates/geopage/classic_geo_page_with_zoom.html
+++ b/tests/geopage/templates/geopage/classic_geo_page_with_zoom.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% load wagtailcore_tags %}
+
+{% block content %}
+    <h1>{{ page.title }}</h1>
+
+    <ul>
+        <li>
+            Point: {{ page.point }}
+        </li>
+        <li>
+            Lat: {{ page.lat }}
+        </li>
+        <li>
+            Lng: {{ page.lng }}
+        </li>
+    </ul>
+{% endblock %}

--- a/tests/geopage/templates/geopage/geo_page.html
+++ b/tests/geopage/templates/geopage/geo_page.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% load wagtailcore_tags %}
+
+{% block content %}
+    <h1>{{ page.title }}</h1>
+
+    <ul>
+        <li>
+            Point: {{ page.location.tuple }}
+        </li>
+        <li>
+            Lat: {{ page.location.y }}
+        </li>
+        <li>
+            Lng: {{ page.location.x }}
+        </li>
+    </ul>
+{% endblock %}

--- a/tests/geopage/templates/geopage/geo_page_with_leaflet.html
+++ b/tests/geopage/templates/geopage/geo_page_with_leaflet.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% load wagtailcore_tags %}
+
+{% block content %}
+    <h1>{{ page.title }}</h1>
+
+    <ul>
+        <li>
+            Point: {{ page.location.tuple }}
+        </li>
+        <li>
+            Lat: {{ page.location.y }}
+        </li>
+        <li>
+            Lng: {{ page.location.x }}
+        </li>
+    </ul>
+{% endblock %}


### PR DESCRIPTION
[TBX Support ticket](https://torchbox.monday.com/boards/1124794299/pulses/1124795788)

This package has been reviewed and tested in light of the [Wagtail 6.2 release](https://docs.wagtail.org/en/stable/releases/6.2.html)

### Wagtail 6.2 upgrade considerations

- [x] [Specifying a dict of distribution IDs for CloudFront cache invalidation is deprecated](https://docs.wagtail.org/en/stable/releases/6.2.html#specifying-a-dict-of-distribution-ids-for-cloudfront-cache-invalidation-is-deprecated)
- [x] [Changes to permissions registration for models with ModelViewSet and SnippetViewSet](https://docs.wagtail.org/en/stable/releases/6.2.html#changes-to-permissions-registration-for-models-with-modelviewset-and-snippetviewset)
- [x] [Deprecation of WAGTAIL_USER_EDIT_FORM, WAGTAIL_USER_CREATION_FORM, and WAGTAIL_USER_CUSTOM_FIELDS settings](https://docs.wagtail.org/en/stable/releases/6.2.html#deprecation-of-wagtail-user-edit-form-wagtail-user-creation-form-and-wagtail-user-custom-fields-settings)
- [x] [Changes to report views with the new Universal Listings UI](https://docs.wagtail.org/en/stable/releases/6.2.html#changes-to-report-views-with-the-new-universal-listings-ui)
- [x] [Deprecation of window.ActivateWorkflowActionsForDashboard and window.ActivateWorkflowActionsForEditView](https://docs.wagtail.org/en/stable/releases/6.2.html#deprecation-of-window-activateworkflowactionsfordashboard-and-window-activateworkflowactionsforeditview)

### Changes made

While Wagtail 6.2 doesn't seem to introduce specific changes that affect this package, this PR adds a few changes, as follows:

- Update test matrix in Github Actions to include Wagtail 6.2
- Bump postgres to v13 because [Django 5.1 doesn't support v12](https://docs.djangoproject.com/en/5.1/ref/databases/#postgresql-notes) (and the test suite breaks with v12)
- Update Dockerfile by replacing Maintainer instruction with label
- Fix a couple of issues encountered when testing:
  - Add missing templates in tests/geopage/templates/geopage/
  - Fix `super()` call in `tests.geopage.models.ClassicGeoPage`
  - Add missing "wagtail.contrib.search_promotions" in test settings

---
